### PR TITLE
fix(template): alt is not able to be manipulated by css

### DIFF
--- a/pyinvoicer/templates/invoice.html
+++ b/pyinvoicer/templates/invoice.html
@@ -15,7 +15,7 @@
     <div class="column-banner-left">
       <div class="logo">
         {% if logo %}
-          <img class="company-img" src="data:image/jpg;base64, {{ logo | safe }}">
+          <img class="company-img" alt="Company Logo" src="data:image/jpg;base64, {{ logo | safe }}">
         {% endif %}
         {{ company_name }}
       </div>

--- a/pyinvoicer/templates/styles.css
+++ b/pyinvoicer/templates/styles.css
@@ -62,7 +62,6 @@ table thead {
 }
 
 .logo .company-img {
-  alt: "Company Logo";
   width: 25px;
   height: 25px;
   vertical-align: top;


### PR DESCRIPTION

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description
<!--Describe what the change is**-->
See issue: #7 

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `inv lint` locally to ensure all linter checks pass
- [ ] Run `inv test` locally to ensure all test cases pass
- [ ] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
Generate the invoice with example yaml.

```
pyinvoicer$ invoicer ./docs/examples/simple-invoice.yaml --output /tmp/invoice-example.pdf
WARNING:weasyprint:Ignored `alt: &#34` at 67:3, unknown property.
WARNING:weasyprint:Error: Expected ':' after declaration name, got ident. at 67:21.
```

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
No warning message reported by weasyprint

As is:
```
WARNING:weasyprint:Ignored `alt: &#34` at 67:3, unknown property.
WARNING:weasyprint:Error: Expected ':' after declaration name, got ident. at 67:21.
```

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
issue: #7 

